### PR TITLE
Manual ScaleIO Client Configuration

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -19,19 +19,19 @@ func (client *Client) GetInstance(systemhref string) (systems []*types.System, e
 	req.SetBasicAuth("", client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&client.Http, req)
+	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
 		return []*types.System{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if systemhref == "" {
-		if err = decodeBody(resp, &systems); err != nil {
+		if err = client.decodeBody(resp, &systems); err != nil {
 			return []*types.System{}, fmt.Errorf("error decoding instances response: %s", err)
 		}
 	} else {
 		system := &types.System{}
-		if err = decodeBody(resp, &system); err != nil {
+		if err = client.decodeBody(resp, &system); err != nil {
 			return []*types.System{}, fmt.Errorf("error decoding instances response: %s", err)
 		}
 		systems = append(systems, system)

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -38,19 +38,19 @@ func (system *System) GetProtectionDomain(protectiondomainhref string) (protecti
 	req.SetBasicAuth("", system.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&system.client.Http, req)
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
 		return []*types.ProtectionDomain{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if protectiondomainhref == "" {
-		if err = decodeBody(resp, &protectionDomains); err != nil {
+		if err = system.client.decodeBody(resp, &protectionDomains); err != nil {
 			return []*types.ProtectionDomain{}, fmt.Errorf("error decoding instances response: %s", err)
 		}
 	} else {
 		protectionDomain := &types.ProtectionDomain{}
-		if err = decodeBody(resp, &protectionDomain); err != nil {
+		if err = system.client.decodeBody(resp, &protectionDomain); err != nil {
 			return []*types.ProtectionDomain{}, fmt.Errorf("error decoding instances response: %s", err)
 		}
 		protectionDomains = append(protectionDomains, protectionDomain)

--- a/scsiinitiator.go
+++ b/scsiinitiator.go
@@ -14,13 +14,13 @@ func (system *System) GetScsiInitiator() (scsiInitiators []types.ScsiInitiator, 
 	req.SetBasicAuth("", system.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&system.client.Http, req)
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
 		return []types.ScsiInitiator{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &scsiInitiators); err != nil {
+	if err = system.client.decodeBody(resp, &scsiInitiators); err != nil {
 		return []types.ScsiInitiator{}, fmt.Errorf("error decoding instances response: %s", err)
 	}
 

--- a/sdc.go
+++ b/sdc.go
@@ -33,13 +33,13 @@ func (system *System) GetSdc() (sdcs []types.Sdc, err error) {
 	req.SetBasicAuth("", system.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&system.client.Http, req)
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
 		return []types.Sdc{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &sdcs); err != nil {
+	if err = system.client.decodeBody(resp, &sdcs); err != nil {
 		return []types.Sdc{}, fmt.Errorf("error decoding instances response: %s", err)
 	}
 
@@ -84,13 +84,13 @@ func (sdc *Sdc) GetStatistics() (statistics *types.Statistics, err error) {
 	req.SetBasicAuth("", sdc.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&sdc.client.Http, req)
+	resp, err := sdc.client.retryCheckResp(&sdc.client.Http, req)
 	if err != nil {
 		return &types.Statistics{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &statistics); err != nil {
+	if err = sdc.client.decodeBody(resp, &statistics); err != nil {
 		return &types.Statistics{}, fmt.Errorf("error decoding instances response: %s", err)
 	}
 
@@ -110,13 +110,13 @@ func (sdc *Sdc) GetVolume() (volumes []*types.Volume, err error) {
 	req.SetBasicAuth("", sdc.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&sdc.client.Http, req)
+	resp, err := sdc.client.retryCheckResp(&sdc.client.Http, req)
 	if err != nil {
 		return []*types.Volume{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &volumes); err != nil {
+	if err = sdc.client.decodeBody(resp, &volumes); err != nil {
 		return []*types.Volume{}, fmt.Errorf("error decoding instances response: %s", err)
 	}
 
@@ -154,7 +154,7 @@ func (volume *Volume) MapVolumeSdc(mapVolumeSdcParam *types.MapVolumeSdcParam) (
 	req.Header.Add("Accept", "application/json;version=1.0")
 	req.Header.Add("Content-Type", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&volume.client.Http, req)
+	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
 		return fmt.Errorf("problem getting response: %v", err)
 	}
@@ -178,7 +178,7 @@ func (volume *Volume) UnmapVolumeSdc(unmapVolumeSdcParam *types.UnmapVolumeSdcPa
 	req.Header.Add("Accept", "application/json;version=1.0")
 	req.Header.Add("Content-Type", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&volume.client.Http, req)
+	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
 		return fmt.Errorf("problem getting response: %v", err)
 	}

--- a/storagepool.go
+++ b/storagepool.go
@@ -37,19 +37,19 @@ func (protectionDomain *ProtectionDomain) GetStoragePool(storagepoolhref string)
 	req.SetBasicAuth("", protectionDomain.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&protectionDomain.client.Http, req)
+	resp, err := protectionDomain.client.retryCheckResp(&protectionDomain.client.Http, req)
 	if err != nil {
 		return []*types.StoragePool{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if storagepoolhref == "" {
-		if err = decodeBody(resp, &storagePools); err != nil {
+		if err = protectionDomain.client.decodeBody(resp, &storagePools); err != nil {
 			return []*types.StoragePool{}, fmt.Errorf("error decoding storage pool response: %s", err)
 		}
 	} else {
 		storagePool := &types.StoragePool{}
-		if err = decodeBody(resp, &storagePool); err != nil {
+		if err = protectionDomain.client.decodeBody(resp, &storagePool); err != nil {
 			return []*types.StoragePool{}, fmt.Errorf("error decoding instances response: %s", err)
 		}
 		storagePools = append(storagePools, storagePool)

--- a/system.go
+++ b/system.go
@@ -52,13 +52,13 @@ func (system *System) GetStatistics() (statistics *types.Statistics, err error) 
 	req.SetBasicAuth("", system.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&system.client.Http, req)
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
 		return &types.Statistics{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &statistics); err != nil {
+	if err = system.client.decodeBody(resp, &statistics); err != nil {
 		return &types.Statistics{}, fmt.Errorf("error decoding instances response: %s", err)
 	}
 
@@ -91,13 +91,13 @@ func (system *System) CreateSnapshotConsistencyGroup(snapshotVolumesParam *types
 	req.Header.Add("Accept", "application/json;version=1.0")
 	req.Header.Add("Content-Type", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&system.client.Http, req)
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
 		return &types.SnapshotVolumesResp{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &snapshotVolumesResp); err != nil {
+	if err = system.client.decodeBody(resp, &snapshotVolumesResp); err != nil {
 		return &types.SnapshotVolumesResp{}, fmt.Errorf("error decoding snapshotvolumes response: %s", err)
 	}
 

--- a/user.go
+++ b/user.go
@@ -14,13 +14,13 @@ func (system *System) GetUser() (user []types.User, err error) {
 	req.SetBasicAuth("", system.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&system.client.Http, req)
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
 		return []types.User{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &user); err != nil {
+	if err = system.client.decodeBody(resp, &user); err != nil {
 		return []types.User{}, fmt.Errorf("error decoding instances response: %s", err)
 	}
 

--- a/volume.go
+++ b/volume.go
@@ -66,14 +66,14 @@ func (storagePool *StoragePool) GetVolume(volumehref, volumeid, ancestorvolumeid
 	req.SetBasicAuth("", storagePool.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&storagePool.client.Http, req)
+	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
 		return []*types.Volume{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if volumehref == "" && volumeid == "" {
-		if err = decodeBody(resp, &volumes); err != nil {
+		if err = storagePool.client.decodeBody(resp, &volumes); err != nil {
 			return []*types.Volume{}, fmt.Errorf("error decoding storage pool response: %s", err)
 		}
 		var volumesNew []*types.Volume
@@ -85,7 +85,7 @@ func (storagePool *StoragePool) GetVolume(volumehref, volumeid, ancestorvolumeid
 		volumes = volumesNew
 	} else {
 		volume := &types.Volume{}
-		if err = decodeBody(resp, &volume); err != nil {
+		if err = storagePool.client.decodeBody(resp, &volume); err != nil {
 			return []*types.Volume{}, fmt.Errorf("error decoding instances response: %s", err)
 		}
 		volumes = append(volumes, volume)
@@ -111,7 +111,7 @@ func (storagePool *StoragePool) FindVolumeID(volumename string) (volumeID string
 	req.Header.Add("Accept", "application/json;version=1.0")
 	req.Header.Add("Content-Type", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&storagePool.client.Http, req)
+	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
 		return "", err
 	}
@@ -201,13 +201,13 @@ func (storagePool *StoragePool) CreateVolume(volume *types.VolumeParam) (volumeR
 	req.Header.Add("Accept", "application/json;version=1.0")
 	req.Header.Add("Content-Type", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&storagePool.client.Http, req)
+	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
 		return &types.VolumeResp{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &volumeResp); err != nil {
+	if err = storagePool.client.decodeBody(resp, &volumeResp); err != nil {
 		return &types.VolumeResp{}, fmt.Errorf("error decoding volume creation response: %s", err)
 	}
 
@@ -228,13 +228,13 @@ func (volume *Volume) GetVTree() (vtree *types.VTree, err error) {
 	req.SetBasicAuth("", volume.client.Token)
 	req.Header.Add("Accept", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&volume.client.Http, req)
+	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
 		return &types.VTree{}, fmt.Errorf("problem getting response: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if err = decodeBody(resp, &vtree); err != nil {
+	if err = volume.client.decodeBody(resp, &vtree); err != nil {
 		return &types.VTree{}, fmt.Errorf("error decoding vtree response: %s", err)
 	}
 	return vtree, nil
@@ -268,7 +268,7 @@ func (volume *Volume) RemoveVolume(removeMode string) (err error) {
 	req.Header.Add("Accept", "application/json;version=1.0")
 	req.Header.Add("Content-Type", "application/json;version=1.0")
 
-	resp, err := retryCheckResp(&volume.client.Http, req)
+	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
 		return fmt.Errorf("problem getting response: %v", err)
 	}


### PR DESCRIPTION
This patch enables the ScaleIO client to be manually configurable
through the usage of a new function called NewWithArgs. This function
allows callers to specify the ScaleIO endpoint as well as the security
flags that are used when creating the ScaleIO client.
