### PR TITLE
Updated drv_cfg path

### DIFF
--- a/sdc.go
+++ b/sdc.go
@@ -129,7 +129,7 @@ func GetSdcLocalGUID() (sdcGUID string, err error) {
 	// /bin/emc/scaleio/drv_cfg --query_guid
 	// sdcKernelGuid := "271bad82-08ee-44f2-a2b1-7e2787c27be1"
 
-	out, err := exec.Command("/bin/emc/scaleio/drv_cfg", "--query_guid").Output()
+	out, err := exec.Command("/opt/emc/scaleio/sdc/bin/drv_cfg", "--query_guid").Output()
 	if err != nil {
 		return "", fmt.Errorf("Error querying volumes: ", err)
 	}

--- a/volume.go
+++ b/volume.go
@@ -138,7 +138,7 @@ func GetLocalVolumeMap() (mappedVolumes []*SdcMappedVolume, err error) {
 
 	mappedVolumesMap := make(map[string]*SdcMappedVolume)
 
-	out, err := exec.Command("/bin/emc/scaleio/drv_cfg", "--query_vols").Output()
+	out, err := exec.Command("/opt/emc/scaleio/sdc/bin/drv_cfg", "--query_vols").Output()
 	if err != nil {
 		return []*SdcMappedVolume{}, fmt.Errorf("Error querying volumes: ", err)
 	}


### PR DESCRIPTION
This PR updates the default drv_cfg path to`/opt/emc/scaleio/sdc/bin/drv_cfg`.  This path is more compatible with other OS distros like CoreOS.
