### PR TITLE
Allow Multi-Version of ScaleIO with GoScaleIO API Bindings

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -38,7 +38,7 @@ func (s *S) SetUpSuite(c *C) {
 		},
 	)
 
-	_, err = client.Authenticate(&ConfigConnect{Username: "username", Password: "password", Endpoint: "http://localhost:4444/api"})
+	_, err = client.Authenticate(&ConfigConnect{Username: "username", Password: "password", Endpoint: "http://localhost:4444/api", Version: "2.0"})
 	if err != nil {
 		panic(err)
 	}
@@ -69,7 +69,7 @@ func TestClient_Authenticate(t *testing.T) {
 		},
 	)
 
-	_, err = client.Authenticate(&ConfigConnect{Username: "username", Password: "password", Endpoint: ""})
+	_, err = client.Authenticate(&ConfigConnect{Username: "username", Password: "password", Endpoint: "", Version: "2.0"})
 	_ = testServer.WaitRequests(1)
 	testServer.Flush()
 	if err != nil {

--- a/instance.go
+++ b/instance.go
@@ -22,7 +22,7 @@ func (client *Client) GetInstance(systemhref string) (systems []*types.System, e
 
 	req := client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version="+client.Version)
+	req.Header.Add("Accept", "application/json;version="+client.configConnect.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -74,7 +74,7 @@ func (client *Client) GetVolume(volumehref, volumeid, ancestorvolumeid, volumena
 
 	req := client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version="+client.Version)
+	req.Header.Add("Accept", "application/json;version="+client.configConnect.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -118,8 +118,8 @@ func (client *Client) FindVolumeID(volumename string) (volumeID string, err erro
 
 	req := client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version="+client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+client.Version)
+	req.Header.Add("Accept", "application/json;version="+client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+client.configConnect.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -161,8 +161,8 @@ func (client *Client) CreateVolume(volume *types.VolumeParam, storagePoolName st
 
 	req := client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version="+client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+client.Version)
+	req.Header.Add("Accept", "application/json;version="+client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+client.configConnect.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -189,7 +189,7 @@ func (client *Client) GetStoragePool(storagepoolhref string) (storagePools []*ty
 
 	req := client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version="+client.Version)
+	req.Header.Add("Accept", "application/json;version="+client.configConnect.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {

--- a/instance.go
+++ b/instance.go
@@ -22,7 +22,7 @@ func (client *Client) GetInstance(systemhref string) (systems []*types.System, e
 
 	req := client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+client.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -74,7 +74,7 @@ func (client *Client) GetVolume(volumehref, volumeid, ancestorvolumeid, volumena
 
 	req := client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+client.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -118,8 +118,8 @@ func (client *Client) FindVolumeID(volumename string) (volumeID string, err erro
 
 	req := client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+client.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -161,8 +161,8 @@ func (client *Client) CreateVolume(volume *types.VolumeParam, storagePoolName st
 
 	req := client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+client.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {
@@ -189,7 +189,7 @@ func (client *Client) GetStoragePool(storagepoolhref string) (storagePools []*ty
 
 	req := client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+client.Version)
 
 	resp, err := client.retryCheckResp(&client.Http, req)
 	if err != nil {

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -36,7 +36,7 @@ func (system *System) GetProtectionDomain(protectiondomainhref string) (protecti
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version="+system.client.Version)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -36,7 +36,7 @@ func (system *System) GetProtectionDomain(protectiondomainhref string) (protecti
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+system.client.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/scsiinitiator.go
+++ b/scsiinitiator.go
@@ -12,7 +12,7 @@ func (system *System) GetScsiInitiator() (scsiInitiators []types.ScsiInitiator, 
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+system.client.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/scsiinitiator.go
+++ b/scsiinitiator.go
@@ -12,7 +12,7 @@ func (system *System) GetScsiInitiator() (scsiInitiators []types.ScsiInitiator, 
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version="+system.client.Version)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/sdc.go
+++ b/sdc.go
@@ -31,7 +31,7 @@ func (system *System) GetSdc() (sdcs []types.Sdc, err error) {
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version="+system.client.Version)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
@@ -82,7 +82,7 @@ func (sdc *Sdc) GetStatistics() (statistics *types.Statistics, err error) {
 
 	req := sdc.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", sdc.client.Token)
-	req.Header.Add("Accept", "application/json;version="+sdc.client.Version)
+	req.Header.Add("Accept", "application/json;version="+sdc.client.configConnect.Version)
 
 	resp, err := sdc.client.retryCheckResp(&sdc.client.Http, req)
 	if err != nil {
@@ -108,7 +108,7 @@ func (sdc *Sdc) GetVolume() (volumes []*types.Volume, err error) {
 
 	req := sdc.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", sdc.client.Token)
-	req.Header.Add("Accept", "application/json;version="+sdc.client.Version)
+	req.Header.Add("Accept", "application/json;version="+sdc.client.configConnect.Version)
 
 	resp, err := sdc.client.retryCheckResp(&sdc.client.Http, req)
 	if err != nil {
@@ -151,8 +151,8 @@ func (volume *Volume) MapVolumeSdc(mapVolumeSdcParam *types.MapVolumeSdcParam) (
 
 	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+volume.client.Version)
+	req.Header.Add("Accept", "application/json;version="+volume.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.configConnect.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
@@ -175,8 +175,8 @@ func (volume *Volume) UnmapVolumeSdc(unmapVolumeSdcParam *types.UnmapVolumeSdcPa
 
 	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+volume.client.Version)
+	req.Header.Add("Accept", "application/json;version="+volume.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.configConnect.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {

--- a/sdc.go
+++ b/sdc.go
@@ -31,7 +31,7 @@ func (system *System) GetSdc() (sdcs []types.Sdc, err error) {
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+system.client.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
@@ -82,7 +82,7 @@ func (sdc *Sdc) GetStatistics() (statistics *types.Statistics, err error) {
 
 	req := sdc.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", sdc.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+sdc.client.Version)
 
 	resp, err := sdc.client.retryCheckResp(&sdc.client.Http, req)
 	if err != nil {
@@ -108,7 +108,7 @@ func (sdc *Sdc) GetVolume() (volumes []*types.Volume, err error) {
 
 	req := sdc.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", sdc.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+sdc.client.Version)
 
 	resp, err := sdc.client.retryCheckResp(&sdc.client.Http, req)
 	if err != nil {
@@ -151,8 +151,8 @@ func (volume *Volume) MapVolumeSdc(mapVolumeSdcParam *types.MapVolumeSdcParam) (
 
 	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
@@ -175,8 +175,8 @@ func (volume *Volume) UnmapVolumeSdc(unmapVolumeSdcParam *types.UnmapVolumeSdcPa
 
 	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {

--- a/storagepool.go
+++ b/storagepool.go
@@ -35,7 +35,7 @@ func (protectionDomain *ProtectionDomain) GetStoragePool(storagepoolhref string)
 
 	req := protectionDomain.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", protectionDomain.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+protectionDomain.client.Version)
 
 	resp, err := protectionDomain.client.retryCheckResp(&protectionDomain.client.Http, req)
 	if err != nil {

--- a/storagepool.go
+++ b/storagepool.go
@@ -35,7 +35,7 @@ func (protectionDomain *ProtectionDomain) GetStoragePool(storagepoolhref string)
 
 	req := protectionDomain.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", protectionDomain.client.Token)
-	req.Header.Add("Accept", "application/json;version="+protectionDomain.client.Version)
+	req.Header.Add("Accept", "application/json;version="+protectionDomain.client.configConnect.Version)
 
 	resp, err := protectionDomain.client.retryCheckResp(&protectionDomain.client.Http, req)
 	if err != nil {

--- a/system.go
+++ b/system.go
@@ -50,7 +50,7 @@ func (system *System) GetStatistics() (statistics *types.Statistics, err error) 
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+system.client.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
@@ -88,8 +88,8 @@ func (system *System) CreateSnapshotConsistencyGroup(snapshotVolumesParam *types
 
 	req := system.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+system.client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+system.client.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/system.go
+++ b/system.go
@@ -50,7 +50,7 @@ func (system *System) GetStatistics() (statistics *types.Statistics, err error) 
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version="+system.client.Version)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {
@@ -88,8 +88,8 @@ func (system *System) CreateSnapshotConsistencyGroup(snapshotVolumesParam *types
 
 	req := system.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version="+system.client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+system.client.Version)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+system.client.configConnect.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -12,7 +12,7 @@ func (system *System) GetUser() (user []types.User, err error) {
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+system.client.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -12,7 +12,7 @@ func (system *System) GetUser() (user []types.User, err error) {
 
 	req := system.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", system.client.Token)
-	req.Header.Add("Accept", "application/json;version="+system.client.Version)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
 
 	resp, err := system.client.retryCheckResp(&system.client.Http, req)
 	if err != nil {

--- a/volume.go
+++ b/volume.go
@@ -64,7 +64,7 @@ func (storagePool *StoragePool) GetVolume(volumehref, volumeid, ancestorvolumeid
 
 	req := storagePool.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", storagePool.client.Token)
-	req.Header.Add("Accept", "application/json;version="+storagePool.client.Version)
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.configConnect.Version)
 
 	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
@@ -108,8 +108,8 @@ func (storagePool *StoragePool) FindVolumeID(volumename string) (volumeID string
 
 	req := storagePool.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", storagePool.client.Token)
-	req.Header.Add("Accept", "application/json;version="+storagePool.client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.Version)
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.configConnect.Version)
 
 	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
@@ -198,8 +198,8 @@ func (storagePool *StoragePool) CreateVolume(volume *types.VolumeParam) (volumeR
 
 	req := storagePool.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", storagePool.client.Token)
-	req.Header.Add("Accept", "application/json;version="+storagePool.client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.Version)
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.configConnect.Version)
 
 	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
@@ -226,7 +226,7 @@ func (volume *Volume) GetVTree() (vtree *types.VTree, err error) {
 
 	req := volume.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
+	req.Header.Add("Accept", "application/json;version="+volume.client.configConnect.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
@@ -265,8 +265,8 @@ func (volume *Volume) RemoveVolume(removeMode string) (err error) {
 	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
-	req.Header.Add("Content-Type", "application/json;version="+volume.client.Version)
+	req.Header.Add("Accept", "application/json;version="+volume.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.configConnect.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {

--- a/volume.go
+++ b/volume.go
@@ -64,7 +64,7 @@ func (storagePool *StoragePool) GetVolume(volumehref, volumeid, ancestorvolumeid
 
 	req := storagePool.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", storagePool.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.Version)
 
 	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
@@ -108,8 +108,8 @@ func (storagePool *StoragePool) FindVolumeID(volumename string) (volumeID string
 
 	req := storagePool.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", storagePool.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.Version)
 
 	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
@@ -198,8 +198,8 @@ func (storagePool *StoragePool) CreateVolume(volume *types.VolumeParam) (volumeR
 
 	req := storagePool.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 	req.SetBasicAuth("", storagePool.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.Version)
 
 	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
 	if err != nil {
@@ -226,7 +226,7 @@ func (volume *Volume) GetVTree() (vtree *types.VTree, err error) {
 
 	req := volume.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {
@@ -265,8 +265,8 @@ func (volume *Volume) RemoveVolume(removeMode string) (err error) {
 	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
 
 	req.SetBasicAuth("", volume.client.Token)
-	req.Header.Add("Accept", "application/json;version=1.0")
-	req.Header.Add("Content-Type", "application/json;version=1.0")
+	req.Header.Add("Accept", "application/json;version="+volume.client.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.Version)
 
 	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
 	if err != nil {


### PR DESCRIPTION
Added new Version parameter to the configConnect struct. Most changes occurred to the HTTP headers. 
