### PR TITLE
No Longer Send SIO API Version

### DIFF
--- a/api.go
+++ b/api.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -71,6 +72,10 @@ func (client *Client) getVersion() (string, error) {
 	version = strings.TrimRight(version, `"`)
 	version = strings.TrimLeft(version, `"`)
 
+	versionRX := regexp.MustCompile(`^(\d+?\.\d+?).*$`)
+	if m := versionRX.FindStringSubmatch(version); len(m) > 0 {
+		return m[1], nil
+	}
 	return version, nil
 }
 


### PR DESCRIPTION
This patch updates the GoScaleIO package to no longer request or send the API version for outgoing API calls. This is due to a change in the SIO 2.0.1 Gateway implementation that causes API calls to fail with "2.0.1" or even "2.0". An issue has been filed with ScaleIO.
