### PR TITLE
Enhance Current API Set

### DIFF
--- a/device.go
+++ b/device.go
@@ -1,0 +1,110 @@
+package goscaleio
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+
+	types "github.com/codedellemc/goscaleio/types/v1"
+)
+
+type Device struct {
+	Device *types.Device
+	client *Client
+}
+
+func NewDevice(client *Client) *Device {
+	return &Device{
+		Device: new(types.Device),
+		client: client,
+	}
+}
+
+func NewDeviceEx(client *Client, device *types.Device) *Device {
+	return &Device{
+		Device: device,
+		client: client,
+	}
+}
+
+func (storagePool *StoragePool) AttachDevice(path string, sdsID string) (string, error) {
+	endpoint := storagePool.client.SIOEndpoint
+
+	deviceParam := &types.DeviceParam{}
+	deviceParam.Name = path
+	deviceParam.DeviceCurrentPathname = path
+	deviceParam.StoragePoolID = storagePool.StoragePool.ID
+	deviceParam.SdsID = sdsID
+	deviceParam.TestMode = "testAndActivate"
+
+	jsonOutput, err := json.Marshal(&deviceParam)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling: %s", err)
+	}
+	endpoint.Path = fmt.Sprintf("/api/types/Device/instances")
+
+	req := storagePool.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
+	req.SetBasicAuth("", storagePool.client.Token)
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+storagePool.client.configConnect.Version)
+
+	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.New("error reading body")
+	}
+
+	var dev types.DeviceResp
+	err = json.Unmarshal(bs, &dev)
+	if err != nil {
+		return "", err
+	}
+
+	return dev.ID, nil
+}
+
+func (storagePool *StoragePool) GetDevice() (devices []types.Device, err error) {
+	endpoint := storagePool.client.SIOEndpoint
+	endpoint.Path = fmt.Sprintf("/api/instances/StoragePool::%v/relationships/Device", storagePool.StoragePool.ID)
+
+	req := storagePool.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
+	req.SetBasicAuth("", storagePool.client.Token)
+	req.Header.Add("Accept", "application/json;version="+storagePool.client.configConnect.Version)
+
+	resp, err := storagePool.client.retryCheckResp(&storagePool.client.Http, req)
+	if err != nil {
+		return []types.Device{}, fmt.Errorf("problem getting response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if err = storagePool.client.decodeBody(resp, &devices); err != nil {
+		return []types.Device{}, fmt.Errorf("error decoding instances response: %s", err)
+	}
+
+	return devices, nil
+}
+
+func (storagePool *StoragePool) FindDevice(field, value string) (device *types.Device, err error) {
+	devices, err := storagePool.GetDevice()
+	if err != nil {
+		return &types.Device{}, nil
+	}
+
+	for _, device := range devices {
+		valueOf := reflect.ValueOf(device)
+		switch {
+		case reflect.Indirect(valueOf).FieldByName(field).String() == value:
+			return &device, nil
+		}
+	}
+
+	return &types.Device{}, errors.New("Couldn't find DEV")
+}

--- a/protectiondomain.go
+++ b/protectiondomain.go
@@ -1,8 +1,11 @@
 package goscaleio
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 
 	types "github.com/codedellemc/goscaleio/types/v1"
 )
@@ -17,6 +20,50 @@ func NewProtectionDomain(client *Client) *ProtectionDomain {
 		ProtectionDomain: new(types.ProtectionDomain),
 		client:           client,
 	}
+}
+
+func NewProtectionDomainEx(client *Client, pd *types.ProtectionDomain) *ProtectionDomain {
+	return &ProtectionDomain{
+		ProtectionDomain: pd,
+		client:           client,
+	}
+}
+
+func (system *System) CreateProtectionDomain(name string) (string, error) {
+	endpoint := system.client.SIOEndpoint
+
+	protectionDomainParam := &types.ProtectionDomainParam{}
+	protectionDomainParam.Name = name
+
+	jsonOutput, err := json.Marshal(&protectionDomainParam)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling: %s", err)
+	}
+	endpoint.Path = fmt.Sprintf("/api/types/ProtectionDomain/instances")
+
+	req := system.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
+	req.SetBasicAuth("", system.client.Token)
+	req.Header.Add("Accept", "application/json;version="+system.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+system.client.configConnect.Version)
+
+	resp, err := system.client.retryCheckResp(&system.client.Http, req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.New("error reading body")
+	}
+
+	var pd types.ProtectionDomainResp
+	err = json.Unmarshal(bs, &pd)
+	if err != nil {
+		return "", err
+	}
+
+	return pd.ID, nil
 }
 
 func (system *System) GetProtectionDomain(protectiondomainhref string) (protectionDomains []*types.ProtectionDomain, err error) {
@@ -81,5 +128,4 @@ func (system *System) FindProtectionDomain(id, name, href string) (protectionDom
 	}
 
 	return &types.ProtectionDomain{}, errors.New("Couldn't find protection domain")
-
 }

--- a/sds.go
+++ b/sds.go
@@ -1,0 +1,122 @@
+package goscaleio
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+
+	types "github.com/codedellemc/goscaleio/types/v1"
+)
+
+type Sds struct {
+	Sds    *types.Sds
+	client *Client
+}
+
+func NewSds(client *Client) *Sds {
+	return &Sds{
+		Sds:    new(types.Sds),
+		client: client,
+	}
+}
+
+func NewSdsEx(client *Client, sds *types.Sds) *Sds {
+	return &Sds{
+		Sds:    sds,
+		client: client,
+	}
+}
+
+func (protectionDomain *ProtectionDomain) CreateSds(name string, ipList []string) (string, error) {
+	endpoint := protectionDomain.client.SIOEndpoint
+
+	sdsParam := &types.SdsParam{}
+	sdsParam.Name = name
+	sdsParam.ProtectionDomainID = protectionDomain.ProtectionDomain.ID
+
+	if len(ipList) == 0 {
+		return "", fmt.Errorf("Must provide at least 1 SDS IP")
+	} else if len(ipList) == 1 {
+		sdsIP := types.SdsIp{IP: ipList[0], Role: "all"}
+		sdsIPList := &types.SdsIpList{sdsIP}
+		sdsParam.IPList = append(sdsParam.IPList, sdsIPList)
+	} else if len(ipList) >= 2 {
+		sdsIP1 := types.SdsIp{IP: ipList[0], Role: "sdcOnly"}
+		sdsIP2 := types.SdsIp{IP: ipList[1], Role: "sdsOnly"}
+		sdsIPList1 := &types.SdsIpList{sdsIP1}
+		sdsIPList2 := &types.SdsIpList{sdsIP2}
+		sdsParam.IPList = append(sdsParam.IPList, sdsIPList1)
+		sdsParam.IPList = append(sdsParam.IPList, sdsIPList2)
+	}
+
+	jsonOutput, err := json.Marshal(&sdsParam)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling: %s", err)
+	}
+	endpoint.Path = fmt.Sprintf("/api/types/Sds/instances")
+
+	req := protectionDomain.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
+	req.SetBasicAuth("", protectionDomain.client.Token)
+	req.Header.Add("Accept", "application/json;version="+protectionDomain.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+protectionDomain.client.configConnect.Version)
+
+	resp, err := protectionDomain.client.retryCheckResp(&protectionDomain.client.Http, req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.New("error reading body")
+	}
+
+	var sds types.SdsResp
+	err = json.Unmarshal(bs, &sds)
+	if err != nil {
+		return "", err
+	}
+
+	return sds.ID, nil
+}
+
+func (protectionDomain *ProtectionDomain) GetSds() (sdss []types.Sds, err error) {
+	endpoint := protectionDomain.client.SIOEndpoint
+	endpoint.Path = fmt.Sprintf("/api/instances/ProtectionDomain::%v/relationships/Sds", protectionDomain.ProtectionDomain.ID)
+
+	req := protectionDomain.client.NewRequest(map[string]string{}, "GET", endpoint, nil)
+	req.SetBasicAuth("", protectionDomain.client.Token)
+	req.Header.Add("Accept", "application/json;version="+protectionDomain.client.configConnect.Version)
+
+	resp, err := protectionDomain.client.retryCheckResp(&protectionDomain.client.Http, req)
+	if err != nil {
+		return []types.Sds{}, fmt.Errorf("problem getting response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if err = protectionDomain.client.decodeBody(resp, &sdss); err != nil {
+		return []types.Sds{}, fmt.Errorf("error decoding instances response: %s", err)
+	}
+
+	return sdss, nil
+}
+
+func (protectionDomain *ProtectionDomain) FindSds(field, value string) (sds *types.Sds, err error) {
+	sdss, err := protectionDomain.GetSds()
+	if err != nil {
+		return &types.Sds{}, nil
+	}
+
+	for _, sds := range sdss {
+		valueOf := reflect.ValueOf(sds)
+		switch {
+		case reflect.Indirect(valueOf).FieldByName(field).String() == value:
+			return &sds, nil
+		}
+	}
+
+	return &types.Sds{}, errors.New("Couldn't find SDS")
+}

--- a/storagepool.go
+++ b/storagepool.go
@@ -1,8 +1,11 @@
 package goscaleio
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 
 	types "github.com/codedellemc/goscaleio/types/v1"
 )
@@ -17,6 +20,51 @@ func NewStoragePool(client *Client) *StoragePool {
 		StoragePool: new(types.StoragePool),
 		client:      client,
 	}
+}
+
+func NewStoragePoolEx(client *Client, pool *types.StoragePool) *StoragePool {
+	return &StoragePool{
+		StoragePool: pool,
+		client:      client,
+	}
+}
+
+func (protectionDomain *ProtectionDomain) CreateStoragePool(name string) (string, error) {
+	endpoint := protectionDomain.client.SIOEndpoint
+
+	storagePoolParam := &types.StoragePoolParam{}
+	storagePoolParam.Name = name
+	storagePoolParam.ProtectionDomainID = protectionDomain.ProtectionDomain.ID
+
+	jsonOutput, err := json.Marshal(&storagePoolParam)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling: %s", err)
+	}
+	endpoint.Path = fmt.Sprintf("/api/types/StoragePool/instances")
+
+	req := protectionDomain.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
+	req.SetBasicAuth("", protectionDomain.client.Token)
+	req.Header.Add("Accept", "application/json;version="+protectionDomain.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+protectionDomain.client.configConnect.Version)
+
+	resp, err := protectionDomain.client.retryCheckResp(&protectionDomain.client.Http, req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.New("error reading body")
+	}
+
+	var sp types.StoragePoolResp
+	err = json.Unmarshal(bs, &sp)
+	if err != nil {
+		return "", err
+	}
+
+	return sp.ID, nil
 }
 
 func (protectionDomain *ProtectionDomain) GetStoragePool(storagepoolhref string) (storagePools []*types.StoragePool, err error) {

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -160,6 +160,14 @@ type ProtectionDomain struct {
 	Links                             []*Link `json:"links"`
 }
 
+type ProtectionDomainParam struct {
+	Name string `json:"name"`
+}
+
+type ProtectionDomainResp struct {
+	ID string `json:"id"`
+}
+
 type Sdc struct {
 	SystemID           string  `json:"systemId"`
 	SdcApproved        bool    `json:"sdcApproved"`
@@ -170,6 +178,88 @@ type Sdc struct {
 	Name               string  `json:"name"`
 	ID                 string  `json:"id"`
 	Links              []*Link `json:"links"`
+}
+
+type SdsIp struct {
+	IP   string `json:"ip"`
+	Role string `json:"role"`
+}
+
+type SdsIpList struct {
+	SdsIP SdsIp `json:"SdsIp"`
+}
+
+type Sds struct {
+	ID                           string       `json:"id"`
+	Name                         string       `json:"name,omitempty"`
+	ProtectionDomainID           string       `json:"protectionDomainId"`
+	IPList                       []*SdsIpList `json:"ipList"`
+	Port                         int          `json:"port,omitempty"`
+	SdsState                     string       `json:"sdsState"`
+	MembershipState              string       `json:"membershipState"`
+	MdmConnectionState           string       `json:"mdmConnectionState"`
+	DrlMode                      string       `json:"drlMode,omitempty"`
+	RmcacheEnabled               bool         `json:"rmcacheEnabled,omitempty"`
+	RmcacheSizeInKb              int          `json:"rmcacheSizeInKb,omitempty"`
+	RmcacheFrozen                bool         `json:"rmcacheFrozen,omitempty"`
+	IsOnVMware                   bool         `json:"isOnVmWare,omitempty"`
+	FaultSetID                   string       `json:"faultSetId,omitempty"`
+	NumOfIoBuffers               int          `json:"numOfIoBuffers,omitempty"`
+	RmcacheMemoryAllocationState string       `json:"RmcacheMemoryAllocationState,omitempty"`
+}
+
+type DeviceInfo struct {
+	DevicePath    string `json:"devicePath"`
+	StoragePoolID string `json:"storagePoolId"`
+	DeviceName    string `json:"deviceName,omitempty"`
+}
+
+type SdsParam struct {
+	Name               string        `json:"name,omitempty"`
+	IPList             []*SdsIpList  `json:"sdsIpList"`
+	Port               int           `json:"sdsPort,omitempty"`
+	DrlMode            string        `json:"drlMode,omitempty"`
+	RmcacheEnabled     bool          `json:"rmcacheEnabled,omitempty"`
+	RmcacheSizeInKb    int           `json:"rmcacheSizeInKb,omitempty"`
+	RmcacheFrozen      bool          `json:"rmcacheFrozen,omitempty"`
+	ProtectionDomainID string        `json:"protectionDomainId"`
+	FaultSetID         string        `json:"faultSetId,omitempty"`
+	NumOfIoBuffers     int           `json:"numOfIoBuffers,omitempty"`
+	DeviceInfoList     []*DeviceInfo `json:"deviceInfoList,omitempty"`
+	ForceClean         bool          `json:"forceClean,omitempty"`
+	DeviceTestTimeSecs int           `json:"deviceTestTimeSecs ,omitempty"`
+	DeviceTestMode     string        `json:"deviceTestMode,omitempty"`
+}
+
+type SdsResp struct {
+	ID string `json:"id"`
+}
+
+type Device struct {
+	ID                     string `json:"id,omitempty"`
+	Name                   string `json:"name,omitempty"`
+	DeviceCurrentPathname  string `json:"deviceCurrentPathname"`
+	DeviceOriginalPathname string `json:"deviceOriginalPathname,omitempty"`
+	DeviceState            string `json:"deviceState,omitempty"`
+	ErrorState             string `json:"errorState,omitempty"`
+	CapacityLimitInKb      int    `json:"capacityLimitInKb,omitempty"`
+	MaxCapacityInKb        int    `json:"maxCapacityInKb,omitempty"`
+	StoragePoolID          string `json:"storagePoolId"`
+	SdsID                  string `json:"sdsId"`
+}
+
+type DeviceParam struct {
+	Name                  string `json:"name,omitempty"`
+	DeviceCurrentPathname string `json:"deviceCurrentPathname"`
+	CapacityLimitInKb     int    `json:"capacityLimitInKb,omitempty"`
+	StoragePoolID         string `json:"storagePoolId"`
+	SdsID                 string `json:"sdsId"`
+	TestTimeSecs          int    `json:"testTimeSecs,omitempty"`
+	TestMode              string `json:"testMode,omitempty"`
+}
+
+type DeviceResp struct {
+	ID string `json:"id"`
 }
 
 type StoragePool struct {
@@ -196,6 +286,21 @@ type StoragePool struct {
 	Name                                             string  `json:"name"`
 	ID                                               string  `json:"id"`
 	Links                                            []*Link `json:"links"`
+}
+
+type StoragePoolParam struct {
+	Name                     string `json:"name"`
+	SparePercentage          int    `json:"sparePercentage,omitempty"`
+	RebuildEnabled           bool   `json:"rebuildEnabled,omitempty"`
+	RebalanceEnabled         bool   `json:"rebalanceEnabled,omitempty"`
+	ProtectionDomainID       string `json:"protectionDomainId"`
+	ZeroPaddingEnabled       bool   `json:"zeroPaddingEnabled,omitempty"`
+	UseRmcache               bool   `json:"useRmcache,omitempty"`
+	RmcacheWriteHandlingMode string `json:"rmcacheWriteHandlingMode,omitempty"`
+}
+
+type StoragePoolResp struct {
+	ID string `json:"id"`
 }
 
 type MappedSdcInfo struct {


### PR DESCRIPTION
Add APIs to:
- Create ProtectionDomains
- Create StoragePools
- Create, List, Find SDSs
- Assign a Device to a StoragePool
- List devices within an SDS

Tested using this sample program against a ScaleIO 2.0.1 cluster.
https://github.com/dvonthenen/goprojects/blob/master/scaleio-test/main.go
