### PR TITLE
Update logrus import: Sirupsen->sirupsen

### DIFF
--- a/api.go
+++ b/api.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	types "github.com/codedellemc/goscaleio/types/v1"
+	log "github.com/sirupsen/logrus"
 )
 
 type Client struct {


### PR DESCRIPTION
Sirupsen changed his github username from upper to lower case, and broke lots of imports: https://github.com/sirupsen/logrus/issues/570
The current guidance is to use the lowercase version https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276.
Kubernetes https://github.com/kubernetes/kubernetes/ imports this repository, and requires the lower-cased import in order to update other dependencies.
This is fairly urgent, as the kubernetes release is days away.  Let me know if there is anything I can do to speed this up.