### PR TITLE
Support for Setting IOPS/Bandwidth Limits on Mapped Volume

### DIFF
--- a/sdc.go
+++ b/sdc.go
@@ -186,3 +186,28 @@ func (volume *Volume) UnmapVolumeSdc(unmapVolumeSdcParam *types.UnmapVolumeSdcPa
 
 	return nil
 }
+
+func (volume *Volume) SetMappedSdcLimits(setMappedSdcLimitsParam *types.SetMappedSdcLimitsParam) (err error) {
+	endpoint := volume.client.SIOEndpoint
+
+	endpoint.Path = fmt.Sprintf("/api/instances/Volume::%s/action/setMappedSdcLimits", volume.Volume.ID)
+
+	jsonOutput, err := json.Marshal(&setMappedSdcLimitsParam)
+	if err != nil {
+		log.Fatalf("error marshaling: %s", err)
+	}
+
+	req := volume.client.NewRequest(map[string]string{}, "POST", endpoint, bytes.NewBufferString(string(jsonOutput)))
+	req.SetBasicAuth("", volume.client.Token)
+	req.Header.Add("Accept", "application/json;version="+volume.client.configConnect.Version)
+	req.Header.Add("Content-Type", "application/json;version="+volume.client.configConnect.Version)
+
+	resp, err := volume.client.retryCheckResp(&volume.client.Http, req)
+	if err != nil {
+		return fmt.Errorf("problem getting response: %v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+

--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -361,6 +361,12 @@ type UnmapVolumeSdcParam struct {
 	AllSdcs              string `json:"allSdcs,omitempty"`
 }
 
+type SetMappedSdcLimitsParam struct {
+	SdcID                string `json:"sdcId,omitempty"`
+	BandwidthLimitInKbps string `json:"bandwidthLimitInKbps,omitempty"`
+	IopsLimit            string `json:"iopsLimit,omitempty"`
+}
+
 type SnapshotDef struct {
 	VolumeID     string `json:"volumeId,omitempty"`
 	SnapshotName string `json:"snapshotName,omitempty"`


### PR DESCRIPTION
Provides sdc function to set throughput and/or iops limits for a mapped volume.