### PR TITLE
Issue #30 : thinCapacityAllocatedInKm metric

### DIFF
--- a/types/v1/types.go
+++ b/types/v1/types.go
@@ -72,6 +72,7 @@ type Statistics struct {
 	SecondaryVacInKb                         int `json:"secondaryVacInKb"`
 	PendingFwdRebuildCapacityInKb            int `json:"pendingFwdRebuildCapacityInKb"`
 	ThinCapacityInUseInKb                    int `json:"thinCapacityInUseInKb"`
+	ThinCapacityAllocatedInKb                int `json:"thinCapacityAllocatedInKm"`
 	AtRestCapacityInKb                       int `json:"atRestCapacityInKb"`
 	ActiveMovingInBckRebuildJobs             int `json:"activeMovingInBckRebuildJobs"`
 	DegradedHealthyCapacityInKb              int `json:"degradedHealthyCapacityInKb"`


### PR DESCRIPTION
Add "thinCapacityAllocatedInKm" metric in `types.Statistics` struct, available for users thanks `(sp *StoragePool) GetStatistics()`.